### PR TITLE
Update UserProfileController.php

### DIFF
--- a/src/Controller/UserProfileController.php
+++ b/src/Controller/UserProfileController.php
@@ -736,7 +736,7 @@ class UserProfileController extends UserController
         Capsule::transaction(function () use ($data, $user, $currentUser) {
             // Update the user and generate success messages
             foreach ($data as $name => $value) {
-                if ($value != $user->$name) {
+                if (property_exists($user, $name) && $value != $user->$name) {
                     $user->$name = $value;
                 }
             }


### PR DESCRIPTION
Adding a check to ensure we only update existing properties of the User prevents Exception messages like this when updating a user:
```
message: "SQLSTATE[42S22]: Column not found: 1054 Unknown column 'uplift_factor' in 'field list' (SQL: update `users` set `uplift_factor` = 3, `users`.`updated_at` = 2021-02-10 10:50:31 where `id` = 8)"
```